### PR TITLE
Navigate to the start/end of rows

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,10 @@ mainloop:
 				set_active_cell(active_cell_x, active_cell_y-1)
 			case termbox.KeyArrowDown:
 				set_active_cell(active_cell_x, active_cell_y+1)
+			case termbox.KeyHome, termbox.KeyCtrlA:
+				set_active_cell(0, active_cell_y)
+			case termbox.KeyEnd, termbox.KeyCtrlE:
+				set_active_cell(len(sheet[0]), active_cell_y)
 			}
 		case termbox.EventResize:
 			render()


### PR DESCRIPTION
Adds support for Home/CtrlA for navigating to the start of the row, and
End/CtrlE for navigating to the end of the row.  

Unfortunately it doesn't look like termbox makes it easy to determine 
if Shift is currently pressed so Shift+Home for first row and Shift+End 
for last row doesn't seem to be (easily?) possible.